### PR TITLE
Add option to specify IP address the server is listening on

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Running `lanshare -u` and opening `localhost:8080` gives the following result:
 
 ## Usage
 ```
-lanshare [-u] [-p <port>] | [-h|-help]
-  -h|-help   display help
-  -p <port>  the port to listen on (default 8080)
-  -u	     whether to allow uploads (default false)
+lanshare [-u] [-host <ip>] [-p <port>] | [-h|-help]
+  -h|-help	  display help
+  -host <ip>  the host to listen on (IP address) (default "0.0.0.0")
+  -p <port>   the port to listen on (default 8080)
+  -u        	whether to allow uploads (default false)
 ```
 

--- a/main.go
+++ b/main.go
@@ -21,14 +21,14 @@ func main() {
 	help := false
 	flag.BoolVar(&help, "help", false, "display help")
 	flag.BoolVar(&help, "h", false, "display help")
-	host := flag.String("host", "0.0.0.0", "the host to listen on")
+	host := flag.String("host", "0.0.0.0", "the host to listen on (IP address)")
 	port := flag.Int("p", 8080, "the port to listen on")
 
 	flag.Parse()
 
 	// validate host parameter
 	if net.ParseIP(*host) == nil {
-		log.Fatalln("Invalid host ip address")
+		log.Fatalln("Invalid host IP address")
 	}
 
 	if help {
@@ -69,18 +69,20 @@ func runServer(allowUploads bool, host string, port int) {
 }
 
 func printAddresses(host string, port int) {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return
-	}
+	var addrs []net.Addr
 
-	// there is a check if using a custom host
-	// this replaces array addrs with a single IP network with mask /32 (IPv4) and /128 (IPv6)
-	if host != "0.0.0.0" && host != "::" {
+	if host == "0.0.0.0" || host == "::" {
+		var err error
+		addrs, err = net.InterfaceAddrs()
+		if err != nil {
+			return
+		}
+	} else {
+		// if using a custom host, use a single IP for the IP list
 		ip := net.ParseIP(host)
 
 		if ip == nil {
-			log.Fatalf("Invalid host ip address: %s\n", host)
+			log.Fatalf("Invalid host IP address: %s\n", host)
 		}
 
 		var mask net.IPMask

--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/mdp/qrterminal/v3"
 	"log"
 	"net"
 	"net/http"
 	"os"
+
+	"github.com/mdp/qrterminal/v3"
 )
 
 const VERSION = "1.0"
@@ -52,7 +53,16 @@ func runServer(allowUploads bool, host string, port int) {
 	fmt.Printf("Listening on port %d.\n", port)
 	printAddresses(host, port)
 
-	err := http.ListenAndServe(fmt.Sprintf("%s:%d", host, port), nil)
+	listenIP := net.ParseIP(host)
+	var ipStr string
+
+	if listenIP.To4() != nil {
+		ipStr = listenIP.String()
+	} else {
+		ipStr = fmt.Sprintf("[%s]", listenIP.String())
+	}
+
+	err := http.ListenAndServe(fmt.Sprintf("%s:%d", ipStr, port), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,14 +76,20 @@ func printAddresses(host string, port int) {
 
 	// there is a check if using a custom host
 	// this replaces array addrs with a single IP network with mask /32 (IPv4) and /128 (IPv6)
-	if host != "0.0.0.0" {
+	if host != "0.0.0.0" && host != "::" {
 		ip := net.ParseIP(host)
 
 		if ip == nil {
 			log.Fatalf("Invalid host ip address: %s\n", host)
 		}
 
-		addrs = []net.Addr{&net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}}
+		var mask net.IPMask
+		if ip.To4() != nil {
+			mask = net.CIDRMask(32, 32)
+		} else {
+			mask = net.CIDRMask(128, 128)
+		}
+		addrs = []net.Addr{&net.IPNet{IP: ip, Mask: mask}}
 	}
 
 	fmt.Println("Open the UI at one of these URLs:")


### PR DESCRIPTION
This PR adds a flag where you can specify which IP does the server listen on, so you dont have to listen on all interfaces.

It currently works with IPv4, will finish it for custom IPv6, because it needs to differentiate network masks for IPv4 and prefix lenght for IPv6

It also doesnt help if i specify `::` (which is valid IPv6 loopback address) and fails with error
```
2025/03/24 23:28:43 listen tcp: address :::8080: too many colons in address
```